### PR TITLE
DOCSUP-42240: Add an example for helper.replace

### DIFF
--- a/en/template-builder/reference/helper.replace.md
+++ b/en/template-builder/reference/helper.replace.md
@@ -2,7 +2,7 @@
 
 Allows you to replace some parts of the string with others.
 
-This helper function returns a string in which all occurrences of 'find`in`data`are replaced with`replace`.
+This helper function returns a string in which all occurrences of `find` in `data` are replaced with `replace`.
 
 Because the `helper.replace` helper returns a string, it can be used in properties that accept string values.
 
@@ -10,9 +10,8 @@ Because the `helper.replace` helper returns a string, it can be used in properti
 
 #|
 || **Name** | **Type** | **Description** ||
-|| `type`<span style="color: red">\*</span> | "helper.replace" | Set component type ||
-|| `data`<span style="color: red">\*</span> | _any_ | Data to perform the replacement on.
-||
+|| `type`<span style="color: red">\*</span> | "helper.replace" | Set component type. ||
+|| `data`<span style="color: red">\*</span> | _any_ | Data to perform the replacement on. ||
 || `find`<span style="color: red">\*</span> | _string_ | The value to search for — the string whose occurrences must be found in `data` and replaced with the string from `replace`. ||
 || `replace`<span style="color: red">\*</span> | _string_ | The value to insert in place of the matches of the `find` value. ||
 |#

--- a/en/template-builder/reference/helper.replace.md
+++ b/en/template-builder/reference/helper.replace.md
@@ -6,6 +6,13 @@ This helper function returns a string in which all occurrences of `find` in `dat
 
 Because the `helper.replace` helper returns a string, it can be used in properties that accept string values.
 
+[View example](https://ya.cc/t/11ypBlCg42Qp6o)
+
+**Components used in the example**
+
+- [view.list](view.list.md): Displays data in a list.
+- [view.text](view.text.md): Adds a block with text.
+
 ## Component properties {#properties}
 
 #|

--- a/en/template-builder/reference/helper.replace.md
+++ b/en/template-builder/reference/helper.replace.md
@@ -6,12 +6,14 @@ This helper function returns a string in which all occurrences of `find` in `dat
 
 Because the `helper.replace` helper returns a string, it can be used in properties that accept string values.
 
-[View example](https://ya.cc/t/11ypBlCg42Qp6o)
+[![View example](../_images/buttons/view-example.svg)](https://ya.cc/t/11ypBlCg42Qp6o)
 
-**Components used in the example**
+{% cut "Components used in the example" %}
 
 - [view.list](view.list.md): Displays data in a list.
 - [view.text](view.text.md): Adds a block with text.
+
+{% endcut %}
 
 ## Component properties {#properties}
 


### PR DESCRIPTION
1) Пример добавила в Танкере.
2) Поставила точку в конце предложения: "Set component type".
3) Поправила заливку кода во втором предложение: ".. of `find` in `data` are replaced with `replace`."